### PR TITLE
introduce Encoder.Error

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -166,9 +166,15 @@ func (enc *Encoder) SetHeader(header []string) error {
 	return enc.w.Write(header)
 }
 
-// Flush flushes the output stream.
+// Flush writes any buffered data to the underlying io.Writer.
+// To check if an error occurred during the Flush, call Error.
 func (enc *Encoder) Flush() {
 	enc.w.Flush()
+}
+
+// Error reports any error that has occurred during a previous Write or Flush.
+func (enc *Encoder) Error() error {
+	return enc.w.Error()
 }
 
 type recordInterface interface {

--- a/encode_test.go
+++ b/encode_test.go
@@ -221,6 +221,9 @@ func TestEncodeAll(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 		enc.Flush()
+		if err := enc.Error(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 		if buf.String() != tc.out {
 			t.Errorf("got %v, expected %v", buf.String(), tc.out)
 		}


### PR DESCRIPTION
It allows to check if an error occurred during the Flush.