### PR TITLE
drop support of Go 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
           - "1.20"
           - "1.19"
           - "1.18"
-          - "1.17"
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/shogo82148/go-header-csv
 
-go 1.17
+go 1.18


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the build configuration to exclude an older version, ensuring tests run against supported versions.
	- Updated the module’s Go version to align with current standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->